### PR TITLE
Fixed README and compile error on unused CGFloat variable

### DIFF
--- a/Classes/NVHGzipFile.m
+++ b/Classes/NVHGzipFile.m
@@ -26,8 +26,6 @@ typedef NS_ENUM(NSInteger, NVHGzipFileErrorType)
 
 @interface NVHGzipFile ()
 
-@property (nonatomic,assign) CGFloat fileSizeFraction;
-
 @end
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Inflate Gzip file
 
 ```objective-c
-[[NVHTarGzip shared] unGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
+[[NVHTarGzip sharedInstance] unGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
     if (gzipError != nil) {
         NSLog(@"Error ungzipping %@", gzipError);
     }
@@ -24,7 +24,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Untar file
 
 ```objective-c
-[[NVHTarGzip shared] unTarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
+[[NVHTarGzip sharedInstance] unTarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
     if (tarError != nil) {
         NSLog(@"Error untarring %@", tarError);
     }
@@ -34,7 +34,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Inflate Gzip and Untar
 
 ```objective-c
-[[NVHTarGzip shared] unTarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
+[[NVHTarGzip sharedInstance] unTarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
     if (error != nil) {
         NSLog(@"Error extracting %@", error);
     }
@@ -44,7 +44,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Deflate Gzip file
 
 ```objective-c
-[[NVHTarGzip shared] gzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
+[[NVHTarGzip sharedInstance] gzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
     if (gzipError != nil) {
         NSLog(@"Error gzipping %@", gzipError);
     }
@@ -54,7 +54,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Tar file
 
 ```objective-c
-[[NVHTarGzip shared] tarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
+[[NVHTarGzip sharedInstance] tarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
     if (tarError != nil) {
         NSLog(@"Error tarring %@", tarError);
     }
@@ -64,7 +64,7 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Deflate Gzip and Tar
 
 ```objective-c
-[[NVHTarGzip shared] tarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
+[[NVHTarGzip sharedInstance] tarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
     if (error != nil) {
         NSLog(@"Error packing %@", error);
     }
@@ -77,61 +77,73 @@ The *tar* implementation is based on [Light-Untar-for-iOS](https://github.com/mh
 #### Inflate Gzip file
 
 ```objective-c
-[[NVHTarGzip shared] unGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
-    if (gzipError != nil) {
-        NSLog(@"Error ungzipping %@", gzipError);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] unGzipFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error ungzipping: %@", [error localizedDescription]);
+}
 ```
 
 #### Untar file
 
 ```objective-c
-[[NVHTarGzip shared] unTarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
-    if (tarError != nil) {
-        NSLog(@"Error untarring %@", tarError);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] unTarFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error untarring: %@", [error localizedDescription]);
+}
 ```
 
 #### Inflate Gzip and Untar
 
 ```objective-c
-[[NVHTarGzip shared] unTarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
-    if (error != nil) {
-        NSLog(@"Error extracting %@", error);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] unTarGzipFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error extracting: %@", [error localizedDescription]);
+}
 ```
 
 #### Deflate Gzip file
 
 ```objective-c
-[[NVHTarGzip shared] gzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* gzipError) {
-    if (gzipError != nil) {
-        NSLog(@"Error gzipping %@", gzipError);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] gzipFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error gzipping: %@", [error localizedDescription]);
+}
 ```
 
 #### Tar file
 
 ```objective-c
-[[NVHTarGzip shared] tarFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* tarError) {
-    if (tarError != nil) {
-        NSLog(@"Error untarring %@", tarError);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] tarFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error tarring: %@", [error localizedDescription]);
+}
 ```
 
 #### Deflate Gzip and Tar
 
 ```objective-c
-[[NVHTarGzip shared] tarGzipFileAtPath:sourcePath toPath:destinationPath completion:^(NSError* error) {
-    if (error != nil) {
-        NSLog(@"Error extracting %@", error);
-    }
-}];
+NSError *error;
+BOOL success = [[NVHTarGzip sharedInstance] tarGzipFileAtPath:sourcePath toPath:destinationPath error:&error];
+if (success) {
+    //continue
+} else {
+    if (error) NSLog(@"Error extracting: %@", [error localizedDescription]);
+}
 ```
 
 ##### Note


### PR DESCRIPTION
-removed unused variable fileSizeFraction (which causes issues being defined as CGFloat with no CoreGraphics includes)

-fixed ReadMe issues. Example synchronous methods were wrong methods.
All examples used wrong sharedInstance reference.