### PR TITLE
Remove pointer after gzFile in NVHGzipFile.m

### DIFF
--- a/Classes/NVHGzipFile.m
+++ b/Classes/NVHGzipFile.m
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, NVHGzipFileErrorType)
 
 @interface NVHGzipFile ()
 
-@property (nonatomic,assign) CGFloat fileSizeFraction;
+@property (nonatomic,assign) double fileSizeFraction;
 
 @end
 
@@ -103,7 +103,7 @@ typedef NS_ENUM(NSInteger, NVHGzipFileErrorType)
 	// Convert source path into something a C library can handle
 	const char *sourceCString = [sourcePath cStringUsingEncoding:NSASCIIStringEncoding];
     
-	gzFile *sourceGzFile = gzopen(sourceCString, "rb");
+	gzFile sourceGzFile = gzopen(sourceCString, "rb");
     
 	unsigned int bufferLength = 1024*256;	//Thats like 256Kb
 	void *buffer = malloc(bufferLength);
@@ -221,7 +221,7 @@ typedef NS_ENUM(NSInteger, NVHGzipFileErrorType)
     // Convert destination path into something a C library can handle
     const char *destinationCString = [destinationPath cStringUsingEncoding:NSASCIIStringEncoding];
     
-    gzFile *destinationGzFile = gzopen(destinationCString, "wb");
+    gzFile destinationGzFile = gzopen(destinationCString, "wb");
     
     unsigned int bufferLength = 1024*256;	//Thats like 256Kb
     void *buffer = malloc(bufferLength);


### PR DESCRIPTION
Commit message:
> Fix the bug with gzFile: you should use it without `*` pointer. Otherwise the compiler will give the error: "Incompatible pointer types initializing 'gzFile *' (aka 'struct gzFile_s **') with an expression of type 'gzFile' (aka 'struct gzFile_s *')"

I believe it's a serious bug. Although, sometimes the existing code may work, it can lead to crashes.

P.S. Thanks for the project! Great job! I tried many pods to untar tar.gz and only this one works without problems. Let's do it even better!